### PR TITLE
improve: Remove superfluous _setRoleAdmin call for UPDATER_ROLE

### DIFF
--- a/contracts/src/SP1Helios.sol
+++ b/contracts/src/SP1Helios.sol
@@ -152,10 +152,6 @@ contract SP1Helios is AccessControlEnumerable {
             revert NoUpdatersProvided();
         }
 
-        // Make UPDATER_ROLE not have any admin roles that can manage it
-        // This freezes the updater set - no role can add or remove updaters
-        _setRoleAdmin(UPDATER_ROLE, bytes32(0));
-
         // Add all updaters
         for (uint256 i = 0; i < params.updaters.length; ++i) {
             address updater = params.updaters[i];

--- a/contracts/test/SP1Helios.t.sol
+++ b/contracts/test/SP1Helios.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.28;
+pragma solidity 0.8.28;
 
 import {Test, console2} from "forge-std/Test.sol";
 import {SP1Helios} from "../src/SP1Helios.sol";

--- a/contracts/test/SP1Helios.t.sol
+++ b/contracts/test/SP1Helios.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.22;
+pragma solidity ^0.8.28;
 
 import {Test, console2} from "forge-std/Test.sol";
 import {SP1Helios} from "../src/SP1Helios.sol";

--- a/contracts/test/SP1Helios.t.sol
+++ b/contracts/test/SP1Helios.t.sol
@@ -67,7 +67,6 @@ contract SP1HeliosTest is Test {
             INITIAL_SYNC_COMMITTEE_HASH
         );
         // Check roles
-        // UPDATER_ROLE is its own admin now, not DEFAULT_ADMIN_ROLE
         assertTrue(helios.hasRole(helios.UPDATER_ROLE(), initialUpdater));
         assertEq(helios.verifier(), address(mockVerifier));
     }


### PR DESCRIPTION
The SP1Helios contract inherits the AccessControlEnumerable contract to enable role-based access control mechanisms. According to the comments, the UPDATER_ROLE should be admin-less, making the updaters set immutable once deployed. As mentioned in the AccessControl contract, by default, the admin role for all roles is DEFAULT_ADMIN_ROLE, which means that only accounts with this role will be able to grant or revoke other roles.

However, the DEFAULT_ADMIN_ROLE's value is set to bytes32(0), making the call in line 141, where the UPDATER_ROLE's admin is being set to bytes32(0), superfluous. Moreover, the comment in the test in line 70 in SP1Helios.t.sol suggests that UPDATER_ROLE should be its own admin, which contradicts the previously mentioned comment in SP1Helios, that the UPDATER_ROLE should be admin less. In addition, the subsequent check in line 71 is only checking that the initialUpdater has the UPDATER_ROLE, and not that the initialUpdater is the admin of the UPDATER_ROLE.

Consider removing the _setRoleAdmin call in SP1Helios to ensure that UPDATER_ROLE has no admin. Since no address is assigned to the DEFAULT_ADMIN_ROLE, the UPDATER_ROLE's admin will remain DEFAULT_ADMIN_ROLE, with no address assigned to this role. Additionally, consider fixing the comment in the test to align with the documentation in the SP1Helios contract.