### PR TITLE
improve: change `if { revert }` statements to `require()`

### DIFF
--- a/contracts/src/SP1Helios.sol
+++ b/contracts/src/SP1Helios.sol
@@ -148,9 +148,7 @@ contract SP1Helios is AccessControlEnumerable {
         verifier = params.verifier;
 
         // Make sure at least one updater is provided
-        if (params.updaters.length == 0) {
-            revert NoUpdatersProvided();
-        }
+        require(params.updaters.length > 0, NoUpdatersProvided());
 
         // Add all updaters
         for (uint256 i = 0; i < params.updaters.length; ++i) {
@@ -175,32 +173,21 @@ contract SP1Helios is AccessControlEnumerable {
 
         uint256 fromHead = po.prevHead;
         // Ensure that po.newHead is strictly greater than po.prevHead
-        if (po.newHead <= fromHead) {
-            revert NonIncreasingHead(po.newHead);
-        }
+        require (po.newHead > fromHead, NonIncreasingHead(po.newHead));
 
         bytes32 storedPrevHeader = headers[fromHead];
-        if (storedPrevHeader == bytes32(0)) {
-            revert PreviousHeaderNotSet(fromHead);
-        }
-
-        if (storedPrevHeader != po.prevHeader) {
-            revert PreviousHeaderMismatch(po.prevHeader, storedPrevHeader);
-        }
+        require (storedPrevHeader != bytes32(0), PreviousHeaderNotSet(fromHead));
+        require(storedPrevHeader == po.prevHeader, PreviousHeaderMismatch(po.prevHeader, storedPrevHeader));
 
         // Check if the head being proved against is older than allowed.
-        if (block.timestamp - slotTimestamp(fromHead) > MAX_SLOT_AGE) {
-            revert PreviousHeadTooOld(fromHead);
-        }
+        require(block.timestamp - slotTimestamp(fromHead) <= MAX_SLOT_AGE, PreviousHeadTooOld(fromHead));
 
         uint256 currentPeriod = getSyncCommitteePeriod(fromHead);
 
         // Note: We should always have a sync committee for the current head.
         // The "start" sync committee hash is the hash of the sync committee that should sign the next update.
         bytes32 currentSyncCommitteeHash = syncCommittees[currentPeriod];
-        if (currentSyncCommitteeHash != po.startSyncCommitteeHash) {
-            revert SyncCommitteeStartMismatch(po.startSyncCommitteeHash, currentSyncCommitteeHash);
-        }
+        require(currentSyncCommitteeHash == po.startSyncCommitteeHash, SyncCommitteeStartMismatch(po.startSyncCommitteeHash, currentSyncCommitteeHash));
 
         // Verify the proof with the associated public values. This will revert if proof invalid.
         ISP1Verifier(verifier).verifyProof(heliosProgramVkey, publicValues, proof);
@@ -253,9 +240,7 @@ contract SP1Helios is AccessControlEnumerable {
 
             // If the next sync committee is already correct, we don't need to update it.
             if (syncCommittees[nextPeriod] != po.nextSyncCommitteeHash) {
-                if (syncCommittees[nextPeriod] != bytes32(0)) {
-                    revert SyncCommitteeAlreadySet(nextPeriod);
-                }
+                require(syncCommittees[nextPeriod] == bytes32(0), SyncCommitteeAlreadySet(nextPeriod));
 
                 syncCommittees[nextPeriod] = po.nextSyncCommitteeHash;
                 emit SyncCommitteeUpdate(nextPeriod, po.nextSyncCommitteeHash);


### PR DESCRIPTION
Addresses N-11.

Note:

Changed all occurrences except `revert NewHeaderMismatch(po.newHead);` , `revert ExecutionStateRootMismatch(po.newHead);`, because their if branch structure would be broken with `require` statements