### PR TITLE
feat: add possibility to request proof with no storage slots

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,6 +20,5 @@
     "script/Cargo.toml",
     "primitives/Cargo.toml"
   ],
-  "rust-analyzer.showUnlinkedFileNotification": false,
-  "rust-analyzer.cargo.features": ["sp1-backend"]
+  "rust-analyzer.showUnlinkedFileNotification": false
 }

--- a/script/Cargo.toml
+++ b/script/Cargo.toml
@@ -5,10 +5,6 @@ edition.workspace = true
 license.workspace = true
 authors.workspace = true
 
-[features]
-default = ["sp1-backend"]
-sp1-backend = []          # Add dependencies here if needed
-
 [[bin]]
 name = "genesis"
 path = "./bin/genesis.rs"

--- a/script/bin/play.rs
+++ b/script/bin/play.rs
@@ -36,17 +36,5 @@ async fn main() -> anyhow::Result<()> {
         }
     }
 
-    /*
-    let slot: u64 = 11467072;
-    let checkpoint = get_checkpoint(slot).await;
-    info!("checkpoint from slot: {}", hex::encode(checkpoint));
-    // let checkpoint = b256!("0xa4c300c4ad14d5b6c507836be6989c25cd04d62fe1a21e2c62ea6b776406eed9");
-    let client = get_client(checkpoint).await;
-    info!(
-        "finalized slot from checkpoint: {}",
-        client.store.finalized_header.beacon().slot
-    );
-    */
-
     Ok(())
 }

--- a/script/src/api.rs
+++ b/script/src/api.rs
@@ -23,7 +23,7 @@ use tokio::net::TcpListener;
 use tokio::task::JoinHandle;
 use tracing::{error, info};
 use utoipa::{OpenApi, ToSchema};
-use utoipa_swagger_ui::{SwaggerUi, Url};
+use utoipa_swagger_ui::{Config, SwaggerUi, Url};
 
 /// Status of a proof generation request
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
@@ -153,20 +153,23 @@ pub struct FinalizedHeaderResponse {
 
 #[derive(OpenApi)]
 #[openapi(
-    paths(health_handler, request_proof_handler, get_proof_handler, get_finalized_header_handler),
+    paths(
+        health_handler,
+        request_proof_handler,
+        get_proof_handler,
+        get_finalized_header_handler
+    ),
     components(
         schemas(
             ApiProofRequest,
             ProofStatusResponse,
             ProofRequestResponse,
             FinalizedHeaderResponse,
-            // list all appropriate ProofStateResponse variants as we add new proof backends.
             ProofStateResponse<SP1HeliosProofData>
         )
     ),
-    tags(
-        (name = "helios-proof-service", description = "Helios Proof Service API")
-    )
+    tags( (name = "helios-proof-service", description = "Helios Proof Service API") ),
+    servers( (url = "/v1") )
 )]
 pub struct ApiDocV1;
 

--- a/script/src/lib.rs
+++ b/script/src/lib.rs
@@ -242,3 +242,64 @@ pub fn init_tracing() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+pub fn verify_storage_slot_proofs(
+    execution_state_root: FixedBytes<32>,
+    contract_storage: ContractStorage,
+) -> Vec<VerifiedStorageSlot> {
+    // Convert the contract address into nibbles for the global MPT proof
+    // We need to keccak256 the address before converting to nibbles for the MPT proof
+    let address_hash = keccak256(contract_storage.address.as_slice());
+    let address_nibbles = Nibbles::unpack(Bytes::copy_from_slice(address_hash.as_ref()));
+    // RLP-encode the `TrieAccount`. This is what's actually stored in the global MPT
+    let mut rlp_encoded_trie_account = Vec::new();
+    contract_storage
+        .expected_value
+        .encode(&mut rlp_encoded_trie_account);
+
+    // 1) Verify the contract's account node in the global MPT:
+    //    We expect to find `rlp_encoded_trie_account` as the trie value for this address.
+    if let Err(e) = proof::verify_proof(
+        execution_state_root,
+        address_nibbles,
+        Some(rlp_encoded_trie_account),
+        &contract_storage.mpt_proof,
+    ) {
+        panic!(
+            "Could not verify the contract's `TrieAccount` in the global MPT for address {}: {}",
+            hex::encode(contract_storage.address),
+            e
+        );
+    }
+
+    // 2) Now that we've verified the contract's `TrieAccount`, use it to verify each storage slot proof
+    let mut verified_slots = Vec::with_capacity(contract_storage.storage_slots.len());
+    for slot in contract_storage.storage_slots {
+        let key = slot.key;
+        let value = slot.expected_value;
+        // We need to keccak256 the slot key before converting to nibbles for the MPT proof
+        let key_hash = keccak256(key.as_slice());
+        let key_nibbles = Nibbles::unpack(Bytes::copy_from_slice(key_hash.as_ref()));
+        // RLP-encode expected value. This is what's actually stored in the contract MPT
+        let mut rlp_encoded_value = Vec::new();
+        value.encode(&mut rlp_encoded_value);
+
+        // Verify the storage proof under the *contract's* storage root
+        if let Err(e) = proof::verify_proof(
+            contract_storage.expected_value.storage_root,
+            key_nibbles,
+            Some(rlp_encoded_value),
+            &slot.mpt_proof,
+        ) {
+            panic!("Storage proof invalid for slot {}: {}", hex::encode(key), e);
+        }
+
+        verified_slots.push(VerifiedStorageSlot {
+            key,
+            value: FixedBytes(value.to_be_bytes()),
+            contractAddress: contract_storage.address,
+        });
+    }
+
+    verified_slots
+}

--- a/script/src/rpc_proxies/execution.rs
+++ b/script/src/rpc_proxies/execution.rs
@@ -72,13 +72,13 @@ impl Proxy {
     pub async fn get_proof(
         &self,
         address: Address,
-        keys: Vec<B256>,
-        // todo? We don't have to require block_id like that. It's easiest for now. Option<BlockId>
+        keys: &[B256],
+        // todo? We don't have to require block_id like that. It's easiest for now. `Option<BlockId>`
         block_id: BlockId,
     ) -> Result<EIP1186AccountProofResponse> {
         let proof = multiplex(
             |client| {
-                let keys = keys.clone();
+                let keys = keys.to_owned();
                 (async move { Self::get_proof_and_check(client, address, keys, block_id).await })
                     .boxed()
             },
@@ -89,7 +89,7 @@ impl Proxy {
     }
 
     /// Requests Merkle proof from execution client. Times out if it rpc call takes longer than 5 seconds
-    // todo: add retries to this via retri
+    // todo? add retries to this. We're using multiple trustworthy RPCs in prod, so at least one should retrun a fine result
     async fn get_proof_and_check(
         client: RootProvider<Http<Client>>,
         address: Address,

--- a/script/src/types.rs
+++ b/script/src/types.rs
@@ -1,9 +1,12 @@
 use crate::api::ProofRequest;
+use alloy::rpc::types::EIP1186AccountProofResponse;
 use alloy_primitives::B256;
 use alloy_rlp::Encodable;
-use tracing::error;
+use anyhow::anyhow;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use sp1_helios_primitives::types::{ContractStorage, StorageSlot};
 use thiserror::Error;
+use tracing::error;
 use utoipa::ToSchema;
 
 /// Unique identifier for a proof request, derived from the Keccak256 hash of its RLP-encoded content.
@@ -112,4 +115,41 @@ pub enum ProofServiceError {
     ProofGenerationFailed(ProofId, String),
     #[error("Internal service error: {0}")]
     Internal(String),
+}
+
+/**
+ * @dev `ContractStorageBuilder` is a helper type to not add any implementations into `primitives/src/`, as that has been audited
+ */
+pub struct ContractStorageBuilder;
+impl ContractStorageBuilder {
+    pub fn build(
+        storage_slots: &[B256],
+        proof: EIP1186AccountProofResponse,
+    ) -> anyhow::Result<ContractStorage> {
+        if proof.storage_proof.len() != storage_slots.len() {
+            return Err(anyhow!("Merkle proof length mismatch."));
+        }
+
+        let storage_slots: Vec<StorageSlot> = storage_slots
+            .iter()
+            .zip(proof.storage_proof)
+            .map(|(&key, proof_item)| StorageSlot {
+                key,
+                expected_value: proof_item.value,
+                mpt_proof: proof_item.proof,
+            })
+            .collect();
+
+        Ok(ContractStorage {
+            address: proof.address,
+            expected_value: alloy_trie::TrieAccount {
+                nonce: proof.nonce,
+                balance: proof.balance,
+                storage_root: proof.storage_hash,
+                code_hash: proof.code_hash,
+            },
+            mpt_proof: proof.account_proof,
+            storage_slots,
+        })
+    }
 }


### PR DESCRIPTION
Instead of always requiring one storage slot to generate a proof for, we not require a vector of storage slots.
This allows us to pass an empty vector and generate a proof with no storage slot proofs, only the head advancement.

This PR also introduces a robustness check: in execution RPC proxy we now check the integrity of the returned Merkle proof before returning it as Ok(..)