### PR TITLE
feat: release checksum

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -154,16 +154,27 @@ jobs:
             --repo ${{ github.repository }} \
             --pattern "${{ env.BIN_NAME }}_*"
 
-      - name: Generate SHA256 checksums
+      - name: Generate SHA256 checksums (JSON)
         run: |
           cd dist
-          # Generate checksums for all binaries
-          sha256sum ${{ env.BIN_NAME }}_* > SHA256SUMS
+          echo "{" > checksums.json
+          first=true
+          for file in ${{ env.BIN_NAME }}_*; do
+            hash=$(sha256sum "$file" | awk '{print $1}')
+            if [ "$first" = true ]; then
+              first=false
+            else
+              echo "," >> checksums.json
+            fi
+            printf '  "%s": "%s"' "$file" "$hash" >> checksums.json
+          done
+          echo "" >> checksums.json
+          echo "}" >> checksums.json
           echo "Generated checksums:"
-          cat SHA256SUMS
+          cat checksums.json
 
       - name: Upload checksums to Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
-          files: dist/SHA256SUMS
+          files: dist/checksums.json

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -67,6 +67,18 @@ jobs:
           tag_name: ${{ github.ref_name }}
           files: dist/${{ env.BIN_NAME }}_${{ env.VERSION }}_${{ matrix.out_name }}
 
+      - name: Compute and upload checksum
+        run: |
+          FILE="dist/${{ env.BIN_NAME }}_${{ env.VERSION }}_${{ matrix.out_name }}"
+          HASH=$(sha256sum "$FILE" | awk '{print $1}')
+          echo "${{ env.BIN_NAME }}_${{ env.VERSION }}_${{ matrix.out_name }} $HASH" > checksum-${{ matrix.out_name }}.txt
+
+      - name: Upload checksum artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: checksum-${{ matrix.out_name }}
+          path: checksum-${{ matrix.out_name }}.txt
+
   # macos-x86_64:
   #   runs-on: macos-13 # Intel runner
   #   steps:
@@ -139,34 +151,41 @@ jobs:
           tag_name: ${{ github.ref_name }}
           files: dist/${{ env.BIN_NAME }}_${{ env.VERSION }}_arm64_darwin
 
+      - name: Compute and upload checksum
+        run: |
+          FILE="dist/${{ env.BIN_NAME }}_${{ env.VERSION }}_arm64_darwin"
+          HASH=$(shasum -a 256 "$FILE" | awk '{print $1}')
+          echo "${{ env.BIN_NAME }}_${{ env.VERSION }}_arm64_darwin $HASH" > checksum-arm64_darwin.txt
+
+      - name: Upload checksum artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: checksum-arm64_darwin
+          path: checksum-arm64_darwin.txt
+
   checksums:
     needs: [linux, macos-arm64]
     runs-on: ubuntu-22.04
     steps:
-      - name: Download release assets
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          mkdir -p dist
-          cd dist
-          # Download all genesis binaries from the release
-          gh release download ${{ github.ref_name }} \
-            --repo ${{ github.repository }} \
-            --pattern "${{ env.BIN_NAME }}_*"
+      - name: Download checksum artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: checksums
+          pattern: checksum-*
+          merge-multiple: true
 
       - name: Generate SHA256 checksums (JSON)
         run: |
-          cd dist
           echo "{" > checksums.json
           first=true
-          for file in ${{ env.BIN_NAME }}_*; do
-            hash=$(sha256sum "$file" | awk '{print $1}')
+          for file in checksums/checksum-*.txt; do
+            read -r filename hash < "$file"
             if [ "$first" = true ]; then
               first=false
             else
               echo "," >> checksums.json
             fi
-            printf '  "%s": "%s"' "$file" "$hash" >> checksums.json
+            printf '  "%s": "%s"' "$filename" "$hash" >> checksums.json
           done
           echo "" >> checksums.json
           echo "}" >> checksums.json
@@ -177,4 +196,4 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
-          files: dist/checksums.json
+          files: checksums.json

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -138,3 +138,32 @@ jobs:
         with:
           tag_name: ${{ github.ref_name }}
           files: dist/${{ env.BIN_NAME }}_${{ env.VERSION }}_arm64_darwin
+
+  checksums:
+    needs: [linux, macos-arm64]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Download release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p dist
+          cd dist
+          # Download all genesis binaries from the release
+          gh release download ${{ github.ref_name }} \
+            --repo ${{ github.repository }} \
+            --pattern "${{ env.BIN_NAME }}_*"
+
+      - name: Generate SHA256 checksums
+        run: |
+          cd dist
+          # Generate checksums for all binaries
+          sha256sum ${{ env.BIN_NAME }}_* > SHA256SUMS
+          echo "Generated checksums:"
+          cat SHA256SUMS
+
+      - name: Upload checksums to Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          files: dist/SHA256SUMS


### PR DESCRIPTION
This PR adds a checksums.json file to each SP1Helios release containing SHA256 hashes for all published binaries. The checksums job runs after all platform builds complete, downloads the release assets, and uploads the checksum file to the same release. This allows consumers to verify binary integrity after downloading.

Example release: https://github.com/across-protocol/sp1-helios/releases/tag/v0.1.0-alpha.19