### PR TITLE
feat: add prover whitelist

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,0 +1,140 @@
+name: release-binaries
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  CRATE_PATH: ./cli
+  BIN_NAME: genesis
+
+jobs:
+  linux:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            out_name: amd64_linux
+          # - target: aarch64-unknown-linux-gnu
+          #   out_name: arm64_linux
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      # Make sure we have modern C++17 cross compilers on Linux
+      - name: Install modern GCC for C++17 (jammy)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            gcc-12 g++-12 \
+            gcc-12-aarch64-linux-gnu g++-12-aarch64-linux-gnu
+
+      - name: Build (release)
+        working-directory: ${{ env.CRATE_PATH }}
+        env:
+          CC_x86_64_unknown_linux_gnu: gcc-12
+          CXX_x86_64_unknown_linux_gnu: g++-12
+          CXXFLAGS_x86_64_unknown_linux_gnu: -std=gnu++17
+          CC_aarch64_unknown_linux_gnu: aarch64-linux-gnu-gcc-12
+          CXX_aarch64_unknown_linux_gnu: aarch64-linux-gnu-g++-12
+          CXXFLAGS_aarch64_unknown_linux_gnu: -std=gnu++17
+          SP1_SKIP_PROGRAM_BUILD: true
+        run: |
+          cargo build --bin ${BIN_NAME} --release --target ${{ matrix.target }}
+
+      - name: Rename binary
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          SRC="target/${{ matrix.target }}/release/${{ env.BIN_NAME }}"
+          DEST="dist/${{ env.BIN_NAME }}_${VERSION}_${{ matrix.out_name }}"
+          mkdir -p dist
+          chmod +x "$SRC"
+          cp -f "$SRC" "$DEST"
+
+      - name: Upload to Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          files: dist/${{ env.BIN_NAME }}_${{ env.VERSION }}_${{ matrix.out_name }}
+
+  # macos-x86_64:
+  #   runs-on: macos-13 # Intel runner
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: dtolnay/rust-toolchain@stable
+  #       with:
+  #         targets: x86_64-apple-darwin
+
+  #     - name: Build (release)
+  #       working-directory: ${{ env.CRATE_PATH }}
+  #       env:
+  #         CC_x86_64_apple_darwin: clang
+  #         CXX_x86_64_apple_darwin: clang++
+  #         CXXFLAGS_x86_64_apple_darwin: -std=c++17
+  #         CARGO_TARGET_DIR: ${{ github.workspace }}/target/${{ runner.os }}-x86_64-apple-darwin-${{ github.run_id }}
+  #         CARGO_BUILD_JOBS: "1"
+  #         SP1_SKIP_PROGRAM_BUILD: true
+  #       run: |
+  #         cargo build --bin ${BIN_NAME} --release --target x86_64-apple-darwin
+
+  #     - name: Rename binary
+  #       run: |
+  #         VERSION="${GITHUB_REF_NAME#v}"
+  #         echo "VERSION=$VERSION" >> $GITHUB_ENV
+  #         SRC=${{ github.workspace }}/target/${{ runner.os }}-x86_64-apple-darwin-${{ github.run_id }}/x86_64-apple-darwin/release/${{ env.BIN_NAME }}
+  #         DEST="dist/${{ env.BIN_NAME }}_${VERSION}_amd64_darwin"
+  #         mkdir -p dist
+  #         chmod +x "$SRC"
+  #         cp -f "$SRC" "$DEST"
+
+  #     - name: Upload to Release
+  #       uses: softprops/action-gh-release@v2
+  #       with:
+  #         tag_name: ${{ github.ref_name }}
+  #         files: dist/${{ env.BIN_NAME }}_${{ env.VERSION }}_amd64_darwin
+
+  macos-arm64:
+    runs-on: macos-14 # Apple Silicon runner
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin
+
+      - name: Build (release)
+        working-directory: ${{ env.CRATE_PATH }}
+        env:
+          CC_aarch64_apple_darwin: clang
+          CXX_aarch64_apple_darwin: clang++
+          CXXFLAGS_aarch64_apple_darwin: -std=c++17
+          CARGO_TARGET_DIR: ${{ github.workspace }}/target/${{ runner.os }}-aarch64-apple-darwin-${{ github.run_id }}
+          CARGO_BUILD_JOBS: "1"
+          SP1_SKIP_PROGRAM_BUILD: true
+        run: |
+          cargo build --bin ${BIN_NAME} --release --target aarch64-apple-darwin
+
+      - name: Rename binary
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          SRC=${{ github.workspace }}/target/${{ runner.os }}-aarch64-apple-darwin-${{ github.run_id }}/aarch64-apple-darwin/release/${{ env.BIN_NAME }}
+          DEST="dist/${{ env.BIN_NAME }}_${VERSION}_arm64_darwin"
+          mkdir -p dist
+          chmod +x "$SRC"
+          cp -f "$SRC" "$DEST"
+
+      - name: Upload to Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          files: dist/${{ env.BIN_NAME }}_${{ env.VERSION }}_arm64_darwin

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -154,16 +154,27 @@ jobs:
             --repo ${{ github.repository }} \
             --pattern "${{ env.BIN_NAME }}_*"
 
-      - name: Generate SHA256 checksums
+      - name: Generate SHA256 checksums (JSON)
         run: |
           cd dist
-          # Generate checksums for all binaries
-          sha256sum ${{ env.BIN_NAME }}_* > SHA256SUMS
+          echo "{" > checksums.json
+          first=true
+          for file in ${{ env.BIN_NAME }}_*; do
+            hash=$(sha256sum "$file" | awk '{print $1}')
+            if [ "$first" = true ]; then
+              first=false
+            else
+              echo "," >> checksums.json
+            fi
+            printf '  "%s": "%s"' "$file" "$hash" >> checksums.json
+          done
+          echo "" >> checksums.json
+          echo "}" >> checksums.json
           echo "Generated checksums:"
-          cat SHA256SUMS
+          cat checksums.json
 
       - name: Upload checksums to Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
-          files: dist/SHA256SUMS
+          files: dist/checksums.json

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -67,6 +67,18 @@ jobs:
           tag_name: ${{ github.ref_name }}
           files: dist/${{ env.BIN_NAME }}_${{ env.VERSION }}_${{ matrix.out_name }}
 
+      - name: Compute and upload checksum
+        run: |
+          FILE="dist/${{ env.BIN_NAME }}_${{ env.VERSION }}_${{ matrix.out_name }}"
+          HASH=$(sha256sum "$FILE" | awk '{print $1}')
+          echo "${{ env.BIN_NAME }}_${{ env.VERSION }}_${{ matrix.out_name }} $HASH" > checksum-${{ matrix.out_name }}.txt
+
+      - name: Upload checksum artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: checksum-${{ matrix.out_name }}
+          path: checksum-${{ matrix.out_name }}.txt
+
   # macos-x86_64:
   #   runs-on: macos-13 # Intel runner
   #   steps:
@@ -139,34 +151,41 @@ jobs:
           tag_name: ${{ github.ref_name }}
           files: dist/${{ env.BIN_NAME }}_${{ env.VERSION }}_arm64_darwin
 
+      - name: Compute and upload checksum
+        run: |
+          FILE="dist/${{ env.BIN_NAME }}_${{ env.VERSION }}_arm64_darwin"
+          HASH=$(shasum -a 256 "$FILE" | awk '{print $1}')
+          echo "${{ env.BIN_NAME }}_${{ env.VERSION }}_arm64_darwin $HASH" > checksum-arm64_darwin.txt
+
+      - name: Upload checksum artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: checksum-arm64_darwin
+          path: checksum-arm64_darwin.txt
+
   checksums:
     needs: [linux, macos-arm64]
     runs-on: ubuntu-22.04
     steps:
-      - name: Download release assets
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          mkdir -p dist
-          cd dist
-          # Download all genesis binaries from the release
-          gh release download ${{ github.ref_name }} \
-            --repo ${{ github.repository }} \
-            --pattern "${{ env.BIN_NAME }}_*"
+      - name: Download checksum artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: checksums
+          pattern: checksum-*
+          merge-multiple: true
 
       - name: Generate SHA256 checksums (JSON)
         run: |
-          cd dist
           echo "{" > checksums.json
           first=true
-          for file in ${{ env.BIN_NAME }}_*; do
-            hash=$(sha256sum "$file" | awk '{print $1}')
+          for file in checksums/checksum-*.txt; do
+            read -r filename hash < "$file"
             if [ "$first" = true ]; then
               first=false
             else
               echo "," >> checksums.json
             fi
-            printf '  "%s": "%s"' "$file" "$hash" >> checksums.json
+            printf '  "%s": "%s"' "$filename" "$hash" >> checksums.json
           done
           echo "" >> checksums.json
           echo "}" >> checksums.json
@@ -177,4 +196,4 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
-          files: dist/checksums.json
+          files: checksums.json

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -138,3 +138,32 @@ jobs:
         with:
           tag_name: ${{ github.ref_name }}
           files: dist/${{ env.BIN_NAME }}_${{ env.VERSION }}_arm64_darwin
+
+  checksums:
+    needs: [linux, macos-arm64]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Download release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p dist
+          cd dist
+          # Download all genesis binaries from the release
+          gh release download ${{ github.ref_name }} \
+            --repo ${{ github.repository }} \
+            --pattern "${{ env.BIN_NAME }}_*"
+
+      - name: Generate SHA256 checksums
+        run: |
+          cd dist
+          # Generate checksums for all binaries
+          sha256sum ${{ env.BIN_NAME }}_* > SHA256SUMS
+          echo "Generated checksums:"
+          cat SHA256SUMS
+
+      - name: Upload checksums to Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          files: dist/SHA256SUMS

--- a/cli/bin/genesis.rs
+++ b/cli/bin/genesis.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use sp1_helios_api::consensus_client::Client;
 use sp1_helios_api::{get_checkpoint, get_latest_checkpoint};
 use sp1_sdk::{utils, HashableKey, Prover, ProverClient};
+use std::default::Default;
 use std::{
     env, fs,
     path::{Path, PathBuf},
@@ -18,15 +19,39 @@ use tree_hash::TreeHash;
 const HELIOS_ELF: &[u8] = include_bytes!("../../elf/sp1-helios-elf");
 
 #[derive(Parser, Debug, Clone)]
-#[command(about = "Get the genesis parameters from a block.")]
+#[command(
+    name = "genesis",
+    version,
+    about = "Get the genesis parameters from a block.",
+    long_about = None,
+    // A man-ish help layout
+    help_template = "\
+{name} — {about}
+
+USAGE:
+  {usage}
+
+OPTIONS:
+{all-args}
+
+EXAMPLES:
+  genesis --slot 12345 --env-file .env.local --out ./contracts
+"
+)]
 pub struct GenesisArgs {
-    #[arg(long)]
+    #[arg(long, help = "The slot to get the genesis parameters from")]
     pub slot: Option<u64>,
-    #[arg(long, default_value = ".env")]
+    #[arg(long, default_value = ".env", help = "The .env file to use")]
     pub env_file: String,
+    #[arg(
+        long,
+        default_value = "contracts",
+        help = "The output directory for the genesis.json file"
+    )]
+    pub out: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct GenesisConfig {
     pub execution_state_root: String,
@@ -52,7 +77,7 @@ pub async fn main() -> Result<()> {
     // This fetches the .env file from the project root. If the command is invoked in the contracts/ directory,
     // the .env file in the root of the repo is used.
     if let Some(root) = find_project_root() {
-        dotenv::from_path(root.join(args.env_file)).ok();
+        dotenv::from_path(root.join(&args.env_file)).ok();
     } else {
         eprintln!(
             "Warning: Could not find project root. {} file not loaded.",
@@ -69,31 +94,41 @@ pub async fn main() -> Result<()> {
     } else {
         checkpoint = get_latest_checkpoint().await;
     }
-    let sp1_prover = env::var("SP1_PROVER").unwrap();
+    let sp1_prover = env::var("SP1_PROVER").expect("SP1_PROVER not set in .env file");
 
     let mut verifier = Address::ZERO;
     if sp1_prover != "mock" {
-        verifier = env::var("SP1_VERIFIER_ADDRESS").unwrap().parse().unwrap();
+        verifier = env::var("SP1_VERIFIER_ADDRESS")
+            .expect("SP1_VERIFIER_ADDRESS not set in .env file")
+            .parse()
+            .expect("Failed to parse SP1_VERIFIER_ADDRESS");
     }
 
     let mut vkey_updater = Address::ZERO;
     if sp1_prover != "mock" {
-        vkey_updater = env::var("VKEY_UPDATER").unwrap().parse().unwrap();
+        vkey_updater = env::var("VKEY_UPDATER")
+            .expect("VKEY_UPDATER not set in .env file")
+            .parse()
+            .expect("Failed to parse VKEY_UPDATER");
     }
 
     // Create a Client and sync to the checkpoint
-    let mut client = Client::<MainnetConsensusSpec, HttpRpc>::from_env()?;
-    client.sync(checkpoint).await?;
+    let mut helios_client = Client::<MainnetConsensusSpec, HttpRpc>::from_env()?;
+    helios_client.sync(checkpoint).await?;
 
-    let finalized_header = client
+    let finalized_header = helios_client
         .store
         .finalized_header
         .clone()
         .beacon()
         .tree_hash_root();
-    let head = client.store.finalized_header.clone().beacon().slot;
-    let sync_committee_hash = client.store.current_sync_committee.clone().tree_hash_root();
-    let genesis_time = client.config.chain.genesis_time;
+    let head = helios_client.store.finalized_header.clone().beacon().slot;
+    let sync_committee_hash = helios_client
+        .store
+        .current_sync_committee
+        .clone()
+        .tree_hash_root();
+    let genesis_time = helios_client.config.chain.genesis_time;
     const SECONDS_PER_SLOT: u64 = 12;
     const SLOTS_PER_EPOCH: u64 = 32;
     const SLOTS_PER_PERIOD: u64 = SLOTS_PER_EPOCH * 256;
@@ -106,31 +141,8 @@ pub async fn main() -> Result<()> {
             .workspace_root,
     );
 
-    // Read the Genesis config from the contracts directory.
-    let mut genesis_config = get_existing_genesis_config(&workspace_root)?;
-
-    genesis_config.genesis_time = genesis_time;
-    genesis_config.seconds_per_slot = SECONDS_PER_SLOT;
-    genesis_config.slots_per_period = SLOTS_PER_PERIOD;
-    genesis_config.slots_per_epoch = SLOTS_PER_EPOCH;
-    genesis_config.sync_committee_hash = format!("0x{:x}", sync_committee_hash);
-    genesis_config.header = format!("0x{:x}", finalized_header);
-    genesis_config.execution_state_root = format!(
-        "0x{:x}",
-        client
-            .store
-            .finalized_header
-            .execution()
-            .expect("Execution payload doesn't exist.")
-            .state_root()
-    );
-    genesis_config.head = head;
-    genesis_config.helios_program_vkey = vk.bytes32();
-    genesis_config.verifier = format!("0x{:x}", verifier);
-    genesis_config.vkey_updater = format!("0x{:x}", vkey_updater);
-
     // Get the account associated with the private key.
-    let private_key = env::var("PRIVATE_KEY").unwrap();
+    let private_key = env::var("PRIVATE_KEY").expect("PRIVATE_KEY not set in .env file");
     let signer: PrivateKeySigner = private_key.parse().expect("Failed to parse private key");
     let deployer_address = signer.address();
 
@@ -155,9 +167,31 @@ pub async fn main() -> Result<()> {
         _ => vec![format!("0x{:x}", deployer_address)],
     };
 
-    genesis_config.updaters = updaters;
+    // Create genesis config with all values
+    let genesis_config = GenesisConfig {
+        genesis_time,
+        seconds_per_slot: SECONDS_PER_SLOT,
+        slots_per_period: SLOTS_PER_PERIOD,
+        slots_per_epoch: SLOTS_PER_EPOCH,
+        sync_committee_hash: format!("0x{:x}", sync_committee_hash),
+        header: format!("0x{:x}", finalized_header),
+        execution_state_root: format!(
+            "0x{:x}",
+            helios_client
+                .store
+                .finalized_header
+                .execution()
+                .expect("Execution payload doesn't exist.")
+                .state_root()
+        ),
+        head,
+        helios_program_vkey: vk.bytes32(),
+        verifier: format!("0x{:x}", verifier),
+        vkey_updater: format!("0x{:x}", vkey_updater),
+        updaters,
+    };
 
-    write_genesis_config(&workspace_root, &genesis_config)?;
+    write_genesis_config(&workspace_root, &genesis_config, args.out)?;
 
     Ok(())
 }
@@ -172,17 +206,13 @@ fn find_project_root() -> Option<PathBuf> {
     Some(path)
 }
 
-/// Get the existing genesis config from the contracts directory.
-fn get_existing_genesis_config(workspace_root: &Path) -> Result<GenesisConfig> {
-    let genesis_config_path = workspace_root.join("contracts").join("genesis.json");
-    let genesis_config_content = std::fs::read_to_string(genesis_config_path)?;
-    let genesis_config: GenesisConfig = serde_json::from_str(&genesis_config_content)?;
-    Ok(genesis_config)
-}
-
-/// Write the genesis config to the contracts directory.
-fn write_genesis_config(workspace_root: &Path, genesis_config: &GenesisConfig) -> Result<()> {
-    let genesis_config_path = workspace_root.join("contracts").join("genesis.json");
+/// Write the genesis config to the specified output directory.
+fn write_genesis_config(
+    workspace_root: &Path,
+    genesis_config: &GenesisConfig,
+    out: String,
+) -> Result<()> {
+    let genesis_config_path = workspace_root.join(out).join("genesis.json");
     fs::write(
         genesis_config_path,
         serde_json::to_string_pretty(&genesis_config)?,

--- a/zk-api/src/lib.rs
+++ b/zk-api/src/lib.rs
@@ -22,8 +22,6 @@ pub mod util;
 pub mod tracing_setup;
 pub use tracing_setup::init_tracing;
 
-pub const CONSENSUS_RPC_ENV_VAR: &str = "SOURCE_CONSENSUS_RPC_URL";
-
 /// Fetch latest checkpoint from chain to bootstrap client to the latest state.
 /// Panics if any step fails.
 pub async fn get_latest_checkpoint() -> B256 {

--- a/zk-api/src/proof_backends/sp1.rs
+++ b/zk-api/src/proof_backends/sp1.rs
@@ -3,19 +3,46 @@
 use crate::{
     types::SP1HeliosProofData, // Concrete ProofOutput type
 };
-use alloy_primitives::hex;
+use alloy_primitives::{hex, Address};
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use sp1_helios_primitives::types::ProofInputs;
 use sp1_sdk::{
-    EnvProver, HashableKey, ProverClient, SP1ProofWithPublicValues, SP1ProvingKey, SP1Stdin,
+    network::FulfillmentStrategy, EnvProver, HashableKey, ProverClient, SP1ProofWithPublicValues,
+    SP1ProvingKey, SP1Stdin,
 };
-use std::sync::Arc;
+use std::{str::FromStr, sync::Arc};
 use tracing::{debug, info};
 
 use super::ProofBackend;
 
 const ELF: &[u8] = include_bytes!("../../../elf/sp1-helios-elf");
+
+/// Default whitelist of reliable provers on the Succinct Prover Network.
+/// These addresses are recommended by Succinct to ensure proof requests are fulfilled reliably.
+/// See: https://docs.succinct.xyz/docs/sp1/prover-network/advanced-usage#whitelist
+const PROVER_WHITELIST: &[&str] = &[
+    "0xD4FCFCE0DEE91A9895C3AD71A6248D57C287A4F5",
+    "0xB3780A2BBBC20A36C86DA1BF4FA0B0D3C4B60DCF",
+    "0x22F87C35B900B117C19CC4C9CA6A9F59FB38FA4D",
+    "0xE6B2B50B3EBA1EFF48B360D636D673459FF5B5E3",
+    "0x546239E8539CE944120CDE00CC1F5338010E4A42",
+    "0x6F7F48E0A79B607061ACB09FA2C0893973A988D5",
+    "0x25204CC3D0F55AEF52936055E4E225DBD611F815",
+    "0x3D008BDB990E69C40AFB6AA7161C91E82F0FA125",
+    "0x4EAC32F0A25EA9D7F22D1AA40735CB761C672BD6",
+    "0x5A00604BF1832E79713ABA108622C18A1F1A4349",
+    "0x5380D2BD50FD183B0D5D24888E05DFD4DD7D7E4D",
+    "0x05CE8CB29375858C5C9010423C43007181453766",
+];
+
+/// Parses the prover whitelist addresses into a vector of `Address`.
+fn get_prover_whitelist() -> Vec<Address> {
+    PROVER_WHITELIST
+        .iter()
+        .map(|addr| Address::from_str(addr).expect("Invalid prover whitelist address"))
+        .collect()
+}
 
 /// An implementation of `ProofBackend` using the SP1 prover.
 #[derive(Clone)]
@@ -59,11 +86,17 @@ impl SP1Backend {
     async fn run_sp1_prover(&self, stdin: SP1Stdin) -> Result<SP1ProofWithPublicValues> {
         let prover_client = self.prover_client.clone();
         let proving_key = self.proving_key.clone();
+        let whitelist = get_prover_whitelist();
 
         debug!(target: "sp1_backend::prove", "Spawning blocking task for SP1 proof generation.");
         // Execute the potentially long-running prover logic in a blocking thread
         let result = tokio::task::spawn_blocking(move || {
-            prover_client.prove(&proving_key, &stdin).groth16().run()
+            prover_client
+                .prove(&proving_key, &stdin)
+                .groth16()
+                .strategy(FulfillmentStrategy::Auction)
+                .whitelist(Some(whitelist))
+                .run()
         })
         .await;
 

--- a/zk-api/src/proof_backends/sp1.rs
+++ b/zk-api/src/proof_backends/sp1.rs
@@ -8,66 +8,83 @@ use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use sp1_helios_primitives::types::ProofInputs;
 use sp1_sdk::{
-    network::FulfillmentStrategy, EnvProver, HashableKey, ProverClient, SP1ProofWithPublicValues,
-    SP1ProvingKey, SP1Stdin,
+    network::FulfillmentStrategy, EnvProver, HashableKey, NetworkProver, ProverClient,
+    SP1ProofWithPublicValues, SP1ProvingKey, SP1Stdin,
 };
-use std::{str::FromStr, sync::Arc};
+use std::{env, str::FromStr, sync::Arc};
 use tracing::{debug, info};
 
 use super::ProofBackend;
 
 const ELF: &[u8] = include_bytes!("../../../elf/sp1-helios-elf");
 
-/// Default whitelist of reliable provers on the Succinct Prover Network.
-/// These addresses are recommended by Succinct to ensure proof requests are fulfilled reliably.
+/// Environment variable for configuring whitelisted provers on the Succinct Prover Network.
+/// Expects a comma-separated list of addresses.
 /// See: https://docs.succinct.xyz/docs/sp1/prover-network/advanced-usage#whitelist
-const PROVER_WHITELIST: &[&str] = &[
-    "0xD4FCFCE0DEE91A9895C3AD71A6248D57C287A4F5",
-    "0xB3780A2BBBC20A36C86DA1BF4FA0B0D3C4B60DCF",
-    "0x22F87C35B900B117C19CC4C9CA6A9F59FB38FA4D",
-    "0xE6B2B50B3EBA1EFF48B360D636D673459FF5B5E3",
-    "0x546239E8539CE944120CDE00CC1F5338010E4A42",
-    "0x6F7F48E0A79B607061ACB09FA2C0893973A988D5",
-    "0x25204CC3D0F55AEF52936055E4E225DBD611F815",
-    "0x3D008BDB990E69C40AFB6AA7161C91E82F0FA125",
-    "0x4EAC32F0A25EA9D7F22D1AA40735CB761C672BD6",
-    "0x5A00604BF1832E79713ABA108622C18A1F1A4349",
-    "0x5380D2BD50FD183B0D5D24888E05DFD4DD7D7E4D",
-    "0x05CE8CB29375858C5C9010423C43007181453766",
-];
+const PROVER_WHITELIST_ENV_VAR: &str = "SP1_PROVER_WHITELIST";
 
-/// Parses the prover whitelist addresses into a vector of `Address`.
-fn get_prover_whitelist() -> Vec<Address> {
-    PROVER_WHITELIST
-        .iter()
-        .map(|addr| Address::from_str(addr).expect("Invalid prover whitelist address"))
-        .collect()
+/// Parses the prover whitelist from the SP1_PROVER_WHITELIST environment variable.
+/// Returns None if the env var is not set or empty (uses SDK default behavior).
+fn get_prover_whitelist() -> Option<Vec<Address>> {
+    let whitelist_str = env::var(PROVER_WHITELIST_ENV_VAR).ok()?;
+    if whitelist_str.trim().is_empty() {
+        return None;
+    }
+
+    let addresses: Vec<Address> = whitelist_str
+        .split(',')
+        .map(|addr| {
+            let trimmed = addr.trim();
+            Address::from_str(trimmed)
+                .unwrap_or_else(|_| panic!("Invalid address in {}: {}", PROVER_WHITELIST_ENV_VAR, trimmed))
+        })
+        .collect();
+
+    Some(addresses)
+}
+
+/// Returns true if SP1_PROVER is set to "network"
+fn is_network_prover() -> bool {
+    env::var("SP1_PROVER")
+        .map(|v| v.to_lowercase() == "network")
+        .unwrap_or(false)
 }
 
 /// An implementation of `ProofBackend` using the SP1 prover.
+/// Supports multiple prover modes via SP1_PROVER env var (network, cpu, mock, cuda).
+/// When SP1_PROVER=network, uses NetworkProver with whitelisted provers.
 #[derive(Clone)]
 pub struct SP1Backend {
-    prover_client: Arc<EnvProver>,
+    env_prover: Arc<EnvProver>,
+    network_prover: Option<Arc<NetworkProver>>,
     proving_key: Arc<SP1ProvingKey>,
 }
 
 impl SP1Backend {
-    // todo: can improve env configurability here
     pub fn from_env() -> Result<Self> {
         info!(target: "sp1_backend::init", "Initializing SP1Backend...");
 
         // Initialize prover client from environment variables
-        let prover_client = Arc::new(ProverClient::from_env());
+        let env_prover = Arc::new(ProverClient::from_env());
         info!(target: "sp1_backend::init", "SP1 ProverClient created from environment.");
 
         // Setup proving and verification keys
-        // Note: This can be computationally intensive
         info!(target: "sp1_backend::init", "Setting up SP1 proving and verification keys...");
-        let (pk, _vk) = prover_client.setup(ELF);
+        let (pk, _vk) = env_prover.setup(ELF);
         info!(target: "sp1_backend::init", "SP1 keys setup complete.");
 
+        // Create NetworkProver if SP1_PROVER=network for whitelist support
+        let network_prover = if is_network_prover() {
+            info!(target: "sp1_backend::init", "Network prover detected, enabling whitelist support.");
+            Some(Arc::new(ProverClient::builder().network().build()))
+        } else {
+            info!(target: "sp1_backend::init", "Using non-network prover mode.");
+            None
+        };
+
         Ok(Self {
-            prover_client,
+            env_prover,
+            network_prover,
             proving_key: Arc::new(pk),
         })
     }
@@ -82,23 +99,38 @@ impl SP1Backend {
         Ok(stdin)
     }
 
-    /// Runs the SP1 prover in a blocking thread.
+    /// Runs the SP1 prover. Uses NetworkProver with whitelist when SP1_PROVER=network,
+    /// otherwise falls back to EnvProver for local/mock proving.
     async fn run_sp1_prover(&self, stdin: SP1Stdin) -> Result<SP1ProofWithPublicValues> {
-        let prover_client = self.prover_client.clone();
-        let proving_key = self.proving_key.clone();
-        let whitelist = get_prover_whitelist();
+        // Use NetworkProver with whitelist if available (SP1_PROVER=network)
+        if let Some(network_prover) = &self.network_prover {
+            let whitelist = get_prover_whitelist();
+            if let Some(ref wl) = whitelist {
+                debug!(target: "sp1_backend::prove", "Using NetworkProver with {} whitelisted provers.", wl.len());
+            } else {
+                debug!(target: "sp1_backend::prove", "Using NetworkProver with SDK default whitelist.");
+            }
 
-        debug!(target: "sp1_backend::prove", "Spawning blocking task for SP1 proof generation.");
-        // Execute the potentially long-running prover logic in a blocking thread
-        let result = tokio::task::spawn_blocking(move || {
-            prover_client
-                .prove(&proving_key, &stdin)
+            return network_prover
+                .prove(&self.proving_key, &stdin)
                 .groth16()
                 .strategy(FulfillmentStrategy::Auction)
-                .whitelist(Some(whitelist))
-                .run()
-        })
-        .await;
+                .whitelist(whitelist)
+                .run_async()
+                .await
+                .context("SP1 network prover run failed");
+        }
+
+        // Fall back to EnvProver for non-network modes (cpu, mock, cuda)
+        debug!(target: "sp1_backend::prove", "Using EnvProver (non-network mode).");
+        let env_prover = self.env_prover.clone();
+        let proving_key = self.proving_key.clone();
+
+        let result: Result<Result<SP1ProofWithPublicValues, _>, _> =
+            tokio::task::spawn_blocking(move || {
+                env_prover.prove(&proving_key, &stdin).groth16().run()
+            })
+            .await;
 
         // todo: Is this meaningful error handling? I feel like we should only have 1 error arm. Flatten errors?
         match result {


### PR DESCRIPTION
Added configurable prover whitelist support for the Succinct Prover Network. When SP1_PROVER=network, proof requests now use FulfillmentStrategy::Auction with a whitelist of prover addresses (configured via SP1_PROVER_WHITELIST env var). This required a dual-prover architecture since the whitelist API is only available on NetworkProver, not the generic EnvProver—non-network modes (cpu/mock/cuda) continue to work unchanged.

Test proof request (whitelist at the bottom of the page) here: https://explorer.succinct.xyz/request/0xbde65934ebe65ff12a573f6781603b08459350bd76e24108d2c95c712cfe9716